### PR TITLE
[bug] use `widgetedit:widget:ready` to actually get ready in question form instead select type

### DIFF
--- a/src/authoring/extensions/validation/essayMaxLength/index.js
+++ b/src/authoring/extensions/validation/essayMaxLength/index.js
@@ -51,22 +51,18 @@ export function run() {
  * @ignore
  */
 function setupListeners() {
-    app.appInstance().on('widgetedit:editor:ready', () => {
-        // Race condition with the event firing and the instance
-        // actually being loaded
-        setTimeout(() => {
-            const widgetType = widgets.type();
+    app.appInstance().on('widgetedit:widget:ready', () => {
+        const widgetType = widgets.type();
 
-            if (state.validTypes.includes(widgetType)) {
-                const elMaxLength = document.querySelector('[data-lrn-qe-input-path="max_length"] input.lrn-qe-input');
+        if (state.validTypes.includes(widgetType)) {
+            const elMaxLength = document.querySelector('[data-lrn-qe-input-path="max_length"] input.lrn-qe-input');
 
-                if (elMaxLength) {
-                    elMaxLength.addEventListener('input', () => {
-                        validateInput(elMaxLength);
-                    });
-                }
+            if (elMaxLength) {
+                elMaxLength.addEventListener('input', () => {
+                    validateInput(elMaxLength);
+                });
             }
-        }, 500);
+        }
     });
 }
 


### PR DESCRIPTION
Hi, I've identified a bug in the essayMaxLength extension. 
When a user clicks to create a new question and is on the 'select question type' screen, it triggers the event [app.appInstance().on('widgetedit:editor:ready')(https://github.com/michaelsharman/LT/blob/main/src/authoring/extensions/validation/essayMaxLength/index.js#L54)`

Consequently, the [widget.type](https://github.com/michaelsharman/LT/blob/main/src/authoring/extensions/validation/essayMaxLength/index.js#L58C19-L58C47) becomes null, leading to the issue described in this line: https://github.com/michaelsharman/LT/blob/main/src/authoring/extensions/validation/essayMaxLength/index.js#L60. As a result, no event listeners are created on the max-length input

<img width="1633" alt="essayMaxLength" src="https://github.com/michaelsharman/LT/assets/30227910/cd65e569-a581-4427-ab83-1587c46d8852">

I used this page to test event fires https://demos.learnosity.com/authoring/events.php
Then see that the correctly event should `widgetedit:editor:ready`, this event fires on select question type instead actual question form

And here is the attached video to prove it works

https://github.com/michaelsharman/LT/assets/30227910/17a9b3b0-9ef5-4901-bea8-04fdb60ceed2

